### PR TITLE
fix(chrome兼容): 低版本浏览器的el.classList.value 的值不存在

### DIFF
--- a/components/Anchor/Anchor.js
+++ b/components/Anchor/Anchor.js
@@ -178,7 +178,7 @@ class Anchor extends Component {
         current = i
       }
     }
-    const classes = list[current].classList.value
+    const classes = list[current].classList.value || Array.from(list[current].classList).join(' ')
     const idx = classes.indexOf('target-')
     const result = classes.slice(idx + 7)
 


### PR DESCRIPTION
代码报错，导致内容滚动时，对应的锚点未变化