### PR TITLE
fix: 修复GroupGrid 新增默认值，第一行的时候无效

### DIFF
--- a/components/GroupGrid/GroupGrid.js
+++ b/components/GroupGrid/GroupGrid.js
@@ -183,21 +183,12 @@ class GroupGrid extends Field {
     return null
   }
 
-  focus() {}
+  focus() { }
 
   addGroup() {
     const { addDefaultValue } = this.props
     const rowData = isFunction(addDefaultValue) ? addDefaultValue.call(this) : addDefaultValue
-    if (this.grid.props.data.length > 0) {
-      this.grid.appendRow({ data: rowData })
-    } else {
-      const tr = this.props.groupDefaults.fields.map((n) => {
-        const item = {}
-        item[n.name] = null
-        return item
-      })
-      this.grid.update({ data: [tr] })
-    }
+    this.grid.props.data.length === 0 ? this.grid.update({ data: [rowData] }) : this.grid.appendRow({ data: rowData })
 
     this._onValueChange()
   }


### PR DESCRIPTION
修复GroupGrid 新增默认值，第一行的时候无效