### PR TITLE
GroupGrid功能扩展

### DIFF
--- a/components/GroupGrid/GroupGrid.js
+++ b/components/GroupGrid/GroupGrid.js
@@ -16,8 +16,11 @@ class GroupGrid extends Field {
 
   _config() {
     const that = this
-    const { groupDefaults, value, actionColumn, gridProps } = this.props
-    const columns = []
+    const { groupDefaults, value, gridProps } = this.props
+    const actionRender = groupDefaults.actionRender || null
+    const actionWidth = groupDefaults.actionWidth || 80
+
+    let columns = []
     groupDefaults.fields.forEach((f) => {
       if (f.hidden !== true) {
         columns.push({
@@ -41,29 +44,41 @@ class GroupGrid extends Field {
         })
       }
     })
-    columns.push(
-      Component.extendProps(
-        {
-          width: 80,
-          cellRender: ({ row }) => {
-            return {
-              component: Toolbar,
-              items: [
-                {
-                  component: 'Button',
-                  text: '移除',
-                  onClick: () => {
-                    row.remove()
-                    that._onValueChange()
+
+    columns = [
+      ...columns,
+      isFunction(actionRender)
+        ? {
+            width: actionWidth,
+            cellRender: ({ row }) => {
+              return {
+                component: Toolbar,
+                items: actionRender({
+                  row: row,
+                  grid: that,
+                }),
+              }
+            },
+          }
+        : {
+            width: 80,
+            cellRender: ({ row }) => {
+              return {
+                component: Toolbar,
+                items: [
+                  {
+                    component: 'Button',
+                    text: '移除',
+                    onClick: () => {
+                      row.remove()
+                      that._onValueChange()
+                    },
                   },
-                },
-              ],
-            }
+                ],
+              }
+            },
           },
-        },
-        actionColumn,
-      ),
-    )
+    ]
 
     this.setProps({
       control: {
@@ -183,7 +198,7 @@ class GroupGrid extends Field {
     return null
   }
 
-  focus() { }
+  focus() {}
 
   addGroup() {
     const gridData = this.grid.props.data || []
@@ -196,7 +211,9 @@ class GroupGrid extends Field {
         return item
       })
     }
-    gridData.length === 0 ? this.grid.update({ data: [rowData] }) : this.grid.appendRow({ data: rowData })
+    gridData.length === 0
+      ? this.grid.update({ data: [rowData] })
+      : this.grid.appendRow({ data: rowData })
 
     this._onValueChange()
   }

--- a/components/GroupGrid/GroupGrid.js
+++ b/components/GroupGrid/GroupGrid.js
@@ -45,40 +45,45 @@ class GroupGrid extends Field {
       }
     })
 
-    columns = [
-      ...columns,
-      isFunction(actionRender)
-        ? {
-            width: actionWidth,
-            cellRender: ({ row }) => {
-              return {
-                component: Toolbar,
-                items: actionRender({
-                  row: row,
-                  grid: that,
-                }),
-              }
-            },
-          }
-        : {
-            width: 80,
-            cellRender: ({ row }) => {
-              return {
-                component: Toolbar,
-                items: [
-                  {
-                    component: 'Button',
-                    text: '移除',
-                    onClick: () => {
-                      row.remove()
-                      that._onValueChange()
-                    },
-                  },
-                ],
-              }
-            },
+    if (isFunction(actionRender)) {
+      columns = [
+        ...columns,
+        {
+          width: actionWidth,
+          cellRender: ({ row }) => {
+            return {
+              component: Toolbar,
+              items: actionRender({
+                row: row,
+                grid: that,
+              }),
+            }
           },
-    ]
+        },
+      ]
+    } else if (actionRender !== null) {
+      columns = [
+        ...columns,
+        {
+          width: 80,
+          cellRender: ({ row }) => {
+            return {
+              component: Toolbar,
+              items: [
+                {
+                  component: 'Button',
+                  text: '移除',
+                  onClick: () => {
+                    row.remove()
+                    that._onValueChange()
+                  },
+                },
+              ],
+            }
+          },
+        },
+      ]
+    }
 
     this.setProps({
       control: {

--- a/components/GroupGrid/demos/action-render.js
+++ b/components/GroupGrid/demos/action-render.js
@@ -23,19 +23,19 @@ define([], function () {
             },
             groupDefaults: {
               nowrap: true,
-              actionRender: false,
-              // actionRender: ({ row, grid }) => {
-              //   return [
-              //     {
-              //       component: 'Button',
-              //       text: '移除',
-              //       onClick: () => {
-              //         row.remove()
-              //         grid._onValueChange()
-              //       },
-              //     },
-              //   ]
-              // },
+              // actionRender: false,
+              actionRender: ({ row, grid }) => {
+                return [
+                  {
+                    component: 'Button',
+                    text: '移除',
+                    onClick: () => {
+                      row.remove()
+                      grid._onValueChange()
+                    },
+                  },
+                ]
+              },
               fields: [
                 {
                   component: 'Textbox',

--- a/components/GroupGrid/demos/action-render.js
+++ b/components/GroupGrid/demos/action-render.js
@@ -1,0 +1,79 @@
+define([], function () {
+  return {
+    title: '自定义操作栏',
+    file: 'action-render',
+    demo: function () {
+      let formRef = null
+
+      return {
+        component: 'Form',
+        ref: (c) => {
+          formRef = c
+        },
+        line: 'outline',
+        striped: true,
+        fields: [
+          {
+            component: 'GroupGrid',
+            name: 'educations',
+            label: '教育经历',
+            onValueChange: (args) => {
+              // eslint-disable-next-line
+              console.log(args)
+            },
+            groupDefaults: {
+              nowrap: true,
+              actionRender: ({ row, grid }) => {
+                return [
+                  {
+                    component: 'Button',
+                    text: '移除',
+                    onClick: () => {
+                      row.remove()
+                      grid._onValueChange()
+                    },
+                  },
+                ]
+              },
+              fields: [
+                {
+                  component: 'Textbox',
+                  name: 'school',
+                  label: '学校名称',
+                  required: true,
+                },
+                {
+                  component: 'Numberbox',
+                  name: 'startYear',
+                  label: '入学年份',
+                },
+              ],
+            },
+
+            value: [
+              { school: '小学', startYear: '2000' },
+              { school: '大学', startYear: '2012' },
+            ],
+          },
+        ],
+        action: [
+          {
+            component: 'Button',
+            text: 'getValue',
+            onClick: () => {
+              // eslint-disable-next-line
+              console.log(formRef.getValue())
+            },
+          },
+          {
+            component: 'Button',
+            text: 'validate',
+            onClick: () => {
+              formRef.validate()
+            },
+          },
+        ],
+      }
+    },
+  }
+})

--- a/components/GroupGrid/demos/action-render.js
+++ b/components/GroupGrid/demos/action-render.js
@@ -23,18 +23,19 @@ define([], function () {
             },
             groupDefaults: {
               nowrap: true,
-              actionRender: ({ row, grid }) => {
-                return [
-                  {
-                    component: 'Button',
-                    text: '移除',
-                    onClick: () => {
-                      row.remove()
-                      grid._onValueChange()
-                    },
-                  },
-                ]
-              },
+              actionRender: false,
+              // actionRender: ({ row, grid }) => {
+              //   return [
+              //     {
+              //       component: 'Button',
+              //       text: '移除',
+              //       onClick: () => {
+              //         row.remove()
+              //         grid._onValueChange()
+              //       },
+              //     },
+              //   ]
+              // },
               fields: [
                 {
                   component: 'Textbox',

--- a/components/GroupGrid/demos/index.js
+++ b/components/GroupGrid/demos/index.js
@@ -4,6 +4,7 @@ define([
   './events.js',
   './field-hidden.js',
   './field-width.js',
+  './action-render.js',
 ], function () {
   return {
     title: 'GroupGrid',

--- a/components/GroupGrid/index.md
+++ b/components/GroupGrid/index.md
@@ -6,11 +6,12 @@
 
 ### props
 
-| 参数            | 说明                                           | 类型 | 默认值 |
-| --------------- | ---------------------------------------------- | ---- | ------ |
-| actionClumn     | 操作列配置                                     | `{}` | -      |
-| gridProps       | grid 属性配置                                  | `{}` | -      |
-| addDefaultValue | 配置添加一行记录时的默认值                     | `{}` | -      |
-| groupDefaults   | 每个子 Group 的默认配置，api 参考 Group 的 api | `{}` | -      |
+| 参数 | 说明 | 类型 | 默认值 |
+| --- | --- | --- | --- |
+| gridProps | grid 属性配置 | `{}` | - |
+| addDefaultValue | 配置添加一行记录时的默认值 | `{}` | - |
+| groupDefaults | 每个子 Group 的默认配置，api 参考 Group 的 api | `{}` | - |
+| GroupDefaults.actionRender | 自定义每个子 Group 右边的操作栏 | `({row, grid})=>{}` | - |
+| GroupDefaults.actionWidth | 自定义每个子 Group 右边的操作栏宽度 | `number` | 80 |
 
 > .tips 其他 props 请参考 Field 以及 Group

--- a/components/GroupGrid/index.md
+++ b/components/GroupGrid/index.md
@@ -11,7 +11,7 @@
 | gridProps | grid 属性配置 | `{}` | - |
 | addDefaultValue | 配置添加一行记录时的默认值 | `{}` | - |
 | groupDefaults | 每个子 Group 的默认配置，api 参考 Group 的 api | `{}` | - |
-| GroupDefaults.actionRender | 自定义每个子 Group 右边的操作栏 | `({row, grid})=>{}` | - |
+| GroupDefaults.actionRender | 自定义每个子 Group 右边的操作栏 | `({row, grid})=>{}` \|`false` | - |
 | GroupDefaults.actionWidth | 自定义每个子 Group 右边的操作栏宽度 | `number` | 80 |
 
 > .tips 其他 props 请参考 Field 以及 Group


### PR DESCRIPTION
Resolves #945 

### TODO

GroupGrid组件新增api：

| GroupDefaults.actionRender | 自定义每个子 Group 右边的操作栏 | `({row, grid})=>{}` \|`false` | - |
| GroupDefaults.actionWidth | 自定义每个子 Group 右边的操作栏宽度 | `number` | 80 |