### PR TITLE
fix: TreeSelect组件setValue时如果第二个参数为false，不触发onValueChange事件，则文本框的值无法显示

### DIFF
--- a/components/Tree/styles/index.less
+++ b/components/Tree/styles/index.less
@@ -28,6 +28,7 @@
     }
 
     >.nom-tree-node-expandable-indicator {
+      flex-shrink: 0;
       width: 30px;
       height: 24px;
 

--- a/components/TreeSelect/TreeSelect.js
+++ b/components/TreeSelect/TreeSelect.js
@@ -368,6 +368,9 @@ class TreeSelect extends Field {
 
     if (options.triggerChange) {
       this._onValueChange()
+    } else {
+      this.currentValue = this.tempValue
+      this.placeholder && this.placeholder.hide()
     }
     this._content.update({ children: this._getContentBadges() })
 

--- a/components/TreeSelect/TreeSelect.js
+++ b/components/TreeSelect/TreeSelect.js
@@ -370,7 +370,9 @@ class TreeSelect extends Field {
       this._onValueChange()
     } else {
       this.currentValue = this.tempValue
-      this.placeholder && this.placeholder.hide()
+      if (this.placeholder) {
+        isNullish(this.currentValue) ? this.placeholder.show() : this.placeholder.hide()
+      }
     }
     this._content.update({ children: this._getContentBadges() })
 


### PR DESCRIPTION
TreeSelect组件setValue时如果第二个参数为false，不触发onValueChange事件，则文本框的值无法显示