### PR TITLE
fix: Grid由于margin布局导致set按钮背景色外漏

### DIFF
--- a/components/Grid/styles/index.less
+++ b/components/Grid/styles/index.less
@@ -14,7 +14,7 @@
 
   .nom-grid-setting {
     position: absolute;
-    top: 8px;
+    top: 6px;
     right: 2px;
     z-index: 11;
     background: var(--nom-grid-header-background-color);

--- a/components/Grid/styles/index.less
+++ b/components/Grid/styles/index.less
@@ -14,14 +14,11 @@
 
   .nom-grid-setting {
     position: absolute;
-    top: 0;
-    right: 0;
+    top: 8px;
+    right: 2px;
     z-index: 11;
     background: var(--nom-grid-header-background-color);
 
-    .nom-grid-setting-btn {
-      margin: 8px 2px 0 0;
-    }
   }
 
   >.nom-grid-header {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/106211371/226504973-6d3be4a0-de3b-4caa-9978-efad0db045b9.png)
