### PR TITLE
feat(Grid): 列设置功能重构

### DIFF
--- a/components/Grid/Grid.js
+++ b/components/Grid/Grid.js
@@ -741,7 +741,13 @@ class Grid extends Component {
     const rowCheckerCount = this.props.rowCheckable ? 1 : 0
     this._customColumnFlag = false
     this._processPinColumnFromSetting(tree)
-    this.setProps({ columns: tree, frozenLeftCols: frozenCount + rowCheckerCount })
+    this.setProps({ columns: tree })
+    if (this.props.allowFrozenCols) {
+      this.setProps({
+        frozenLeftCols: frozenCount < 1 ? 0 : frozenCount + rowCheckerCount
+      })
+    }
+
     this._processColumns()
     this._calcMinWidth()
     this.render()
@@ -1214,6 +1220,16 @@ class Grid extends Component {
   }
 
   handlePinClick(data) {
+
+    if (this.pinColumns.length >= this.props.frozenLimit && !data.fixed) {
+      new nomui.Message({
+        content: `最多只能冻结${this.props.frozenLimit}项`,
+        type: 'warning',
+      })
+      return
+    }
+
+
     // 取消初始化固定列时(无缓存配置时)
     if (data.fixed && this.pinColumns.length < 1) {
       let num = this.props.frozenLeftCols
@@ -1305,7 +1321,8 @@ Grid.defaults = {
   frozenHeader: false,
   frozenLeftCols: null,
   frozenRightCols: null,
-  allowFrozenCols: false,
+  allowFrozenCols: true,
+  frozenLimit: 5, // 最大允许固定左侧列数目
   onSort: null,
   forceSort: false,
   sortCacheable: false,
@@ -1336,7 +1353,7 @@ Grid.defaults = {
 
   columnFrozenable: false, // 允许固定列
   // columnFrozenable.cache: boolean 固定列的结果保存至localstorage
-  frozenLimit: 5, // 最大允许固定左侧列数目
+
   striped: false,
   showTitle: false,
   ellipsis: false,

--- a/components/Grid/Grid.js
+++ b/components/Grid/Grid.js
@@ -139,7 +139,9 @@ class Grid extends Component {
             classes: {
               'nom-grid-setting-btn': true,
             },
-            tooltip: '列设置',
+            attrs: {
+              title: '列设置',
+            },
             onClick: () => {
               this.showSetting()
             },
@@ -269,7 +271,7 @@ class Grid extends Component {
         // 存在则表示当前数据不是最顶层数据
 
         // 这里的map中的数据是引用了arr的它的指向还是arr，当mapItem改变时arr也会改变
-        ;(mapItem[childrenField] || (mapItem[childrenField] = [])).push(child) // 这里判断mapItem中是否存在childrenField, 存在则插入当前数据, 不存在则赋值childrenField为[]然后再插入当前数据
+        ; (mapItem[childrenField] || (mapItem[childrenField] = [])).push(child) // 这里判断mapItem中是否存在childrenField, 存在则插入当前数据, 不存在则赋值childrenField为[]然后再插入当前数据
       } else {
         // 不存在则是组顶层数据
         treeData.push(child)

--- a/components/Grid/Grid.js
+++ b/components/Grid/Grid.js
@@ -691,7 +691,11 @@ class Grid extends Component {
     })
   }
 
-  handleColumnsSetting(params) {
+  _updateOriginColumns(data) {
+    this.popupTreeData = this.originColumns = data
+  }
+
+  handleColumnsSetting(params, frozenCount) {
     const tree = params
 
     const that = this
@@ -735,7 +739,7 @@ class Grid extends Component {
 
     this._customColumnFlag = false
     this._processPinColumnFromSetting(tree)
-    this.setProps({ columns: tree })
+    this.setProps({ columns: tree, frozenLeftCols: frozenCount })
     this._processColumns()
     this._calcMinWidth()
     this.render()

--- a/components/Grid/Grid.js
+++ b/components/Grid/Grid.js
@@ -738,10 +738,10 @@ class Grid extends Component {
     if (this._gridColumsStoreKey) {
       localStorage.setItem(this._gridColumsStoreKey, JSON.stringify(this.getMappedColumns(tree)))
     }
-
+    const rowCheckerCount = this.props.rowCheckable ? 1 : 0
     this._customColumnFlag = false
     this._processPinColumnFromSetting(tree)
-    this.setProps({ columns: tree, frozenLeftCols: frozenCount })
+    this.setProps({ columns: tree, frozenLeftCols: frozenCount + rowCheckerCount })
     this._processColumns()
     this._calcMinWidth()
     this.render()

--- a/components/Grid/Grid.js
+++ b/components/Grid/Grid.js
@@ -1336,7 +1336,7 @@ Grid.defaults = {
 
   columnFrozenable: false, // 允许固定列
   // columnFrozenable.cache: boolean 固定列的结果保存至localstorage
-
+  frozenLimit: 1, // 最大允许固定左侧列数目
   striped: false,
   showTitle: false,
   ellipsis: false,

--- a/components/Grid/Grid.js
+++ b/components/Grid/Grid.js
@@ -1336,7 +1336,7 @@ Grid.defaults = {
 
   columnFrozenable: false, // 允许固定列
   // columnFrozenable.cache: boolean 固定列的结果保存至localstorage
-  frozenLimit: 1, // 最大允许固定左侧列数目
+  frozenLimit: 5, // 最大允许固定左侧列数目
   striped: false,
   showTitle: false,
   ellipsis: false,

--- a/components/Grid/GridSettingPopup.js
+++ b/components/Grid/GridSettingPopup.js
@@ -42,6 +42,7 @@ class GridSettingPopup extends Modal {
             ref: (c) => {
               that.transferRef = c
             },
+            allowFrozenCols: that.grid.props.allowFrozenCols,
             frozenLimit: that.grid.props.frozenLimit,
             value: this.grid.getMappedColumns(this.grid.props.columns),
             frozenCount: that.grid.props.frozenLeftCols - rowCheckerCount,

--- a/components/Grid/GridSettingPopup.js
+++ b/components/Grid/GridSettingPopup.js
@@ -1,5 +1,6 @@
 import Component from '../Component/index'
 import Modal from '../Modal/index'
+import GridSettingTransfer from './GridSettingTransfer'
 
 class GridSettingPopup extends Modal {
   constructor(props, ...mixins) {
@@ -12,6 +13,7 @@ class GridSettingPopup extends Modal {
     super._created()
     this.grid = this.props.grid
     this.tree = null
+    this.tempArr = []
   }
 
   _config() {
@@ -32,30 +34,13 @@ class GridSettingPopup extends Modal {
         },
         body: {
           children: {
-            attrs: {
-              style: {
-                maxHeight: '50vh',
-                overflow: 'auto',
-              },
-            },
-            component: 'Tree',
-            showline: true,
-            data: that.customizableColumns(that.grid.popupTreeData),
-            nodeCheckable: {
-              checkedNodeKeys: that.grid.getMappedColumns(that.grid.props.columns),
-            },
-            multiple: true,
-            sortable: {
-              showHandler: true,
-            },
-
+            component: GridSettingTransfer,
             ref: (c) => {
-              this.tree = c
+              that.transferRef = c
             },
-            dataFields: {
-              text: 'title',
-              key: 'field',
-            },
+            value: this.grid.getMappedColumns(this.grid.props.columns),
+            frozenCount: that.grid.props.frozenLeftCols,
+            data: that.customizableColumns(that.grid.popupTreeData),
           },
         },
         footer: {
@@ -70,16 +55,6 @@ class GridSettingPopup extends Modal {
             cols: [
               {
                 grow: true,
-                children: {
-                  component: 'Button',
-                  text: '全选',
-                  ref: (c) => {
-                    this.checkallBtn = c
-                  },
-                  onClick: () => {
-                    this._toogleCheckall()
-                  },
-                },
               },
               {
                 children: {
@@ -87,26 +62,7 @@ class GridSettingPopup extends Modal {
                   type: 'primary',
                   text: '确定',
                   onClick: function () {
-                    const list = that.tree.getCheckedNodesData()
-                    const lockedList = list.filter((n) => {
-                      return n.disabled === true
-                    })
-
-                    if (
-                      list.length === 0 ||
-                      (list.length === lockedList.length && list.length === 1)
-                    ) {
-                      new nomui.Alert({
-                        type: 'info',
-                        title: '提示',
-                        description: '请至少保留一列数据',
-                      })
-                      return false
-                    }
-                    that.grid.popupTreeData = that.grid.originColumns = that._sortCustomizableColumns(
-                      that.tree.getData(),
-                    )
-                    that.grid.handleColumnsSetting(that._sortCustomizableColumns(list))
+                    that._fixDataOrder()
                   },
                 },
               },
@@ -126,6 +82,68 @@ class GridSettingPopup extends Modal {
     })
 
     super._config()
+  }
+
+  _fixDataOrder() {
+    const list = this.transferRef.getSelectedData()
+    const selected = JSON.parse(JSON.stringify(list))
+    const frozenCount = this.transferRef.getFrozenCount()
+
+    const lockedList = list.filter((n) => {
+      return n.disabled === true
+    })
+
+    if (list.length === 0 || (list.length === lockedList.length && list.length === 1)) {
+      new nomui.Alert({
+        type: 'info',
+        title: '提示',
+        description: '请至少保留一列数据',
+      })
+      return false
+    }
+    const originData = this.transferRef.getData()
+    const result = this._mapTree(list, originData)
+
+    this.grid._updateOriginColumns(this._sortCustomizableColumns(result))
+
+    this.grid.handleColumnsSetting(this._sortCustomizableColumns(selected), frozenCount)
+  }
+
+  _findItem(arr, key) {
+    for (let i = 0; i < arr.length; i++) {
+      if (arr[i].field === key) {
+        this.tempArr = arr[i].children
+        break
+      }
+      if (arr[i].children) {
+        this._findItem(arr[i].children, key)
+      }
+    }
+  }
+
+  _mapTree(data, origin) {
+    data = this._concatArr(data, origin)
+    for (let i = 0; i < data.length; i++) {
+      if (data[i].children) {
+        this._findItem(origin, data[i].field)
+        const related = this.tempArr
+        data[i].children = this._mapTree(data[i].children, related || [])
+      }
+    }
+
+    return data
+  }
+
+  _concatArr(target, related) {
+    const restItem = related.filter((n) => {
+      return (
+        target.findIndex((x) => {
+          return x.field === n.field
+        }) === -1
+      )
+    })
+
+    return [...target, ...restItem]
   }
 
   getMappedColumns(param) {

--- a/components/Grid/GridSettingPopup.js
+++ b/components/Grid/GridSettingPopup.js
@@ -22,7 +22,7 @@ class GridSettingPopup extends Modal {
 
   _config() {
     const that = this
-
+    const rowCheckerCount = that.grid.props.rowCheckable ? 1 : 0
     this.setProps({
       classes: {
         'nom-grid-setting-panel': true,
@@ -44,7 +44,7 @@ class GridSettingPopup extends Modal {
             },
             frozenLimit: that.grid.props.frozenLimit,
             value: this.grid.getMappedColumns(this.grid.props.columns),
-            frozenCount: that.grid.props.frozenLeftCols,
+            frozenCount: that.grid.props.frozenLeftCols - rowCheckerCount,
             data: that.customizableColumns(that.grid.popupTreeData),
           },
         },

--- a/components/Grid/GridSettingPopup.js
+++ b/components/Grid/GridSettingPopup.js
@@ -42,6 +42,7 @@ class GridSettingPopup extends Modal {
             ref: (c) => {
               that.transferRef = c
             },
+            frozenLimit: that.grid.props.frozenLimit,
             value: this.grid.getMappedColumns(this.grid.props.columns),
             frozenCount: that.grid.props.frozenLeftCols,
             data: that.customizableColumns(that.grid.popupTreeData),

--- a/components/Grid/GridSettingPopup.js
+++ b/components/Grid/GridSettingPopup.js
@@ -4,7 +4,11 @@ import GridSettingTransfer from './GridSettingTransfer'
 
 class GridSettingPopup extends Modal {
   constructor(props, ...mixins) {
-    const defaults = {}
+    const defaults = {
+      size: {
+        width: 545
+      }
+    }
 
     super(Component.extendProps(defaults, props), ...mixins)
   }

--- a/components/Grid/GridSettingTransfer.js
+++ b/components/Grid/GridSettingTransfer.js
@@ -367,10 +367,19 @@ class GridSettingTransfer extends Field {
     return checkedNodes
   }
 
+  _showParent(node) {
+    const p = node.parentNode.parentNode
+    if (p.classList.contains('nom-tree-node')) {
+      p.classList.remove('s-hidden')
+      this._showParent(p)
+    }
+  }
+
   _onSourceSearch(val) {
     this.sourceTree.element.querySelectorAll('.nom-tree-node').forEach((n) => {
       if (!val || n.querySelector('.nom-tree-node-content-text').innerHTML.includes(val)) {
         n.classList.remove('s-hidden')
+        this._showParent(n)
       } else {
         n.classList.add('s-hidden')
       }
@@ -381,6 +390,7 @@ class GridSettingTransfer extends Field {
     this.targetTree.element.querySelectorAll('.nom-tree-node').forEach((n) => {
       if (!val || n.querySelector('.nom-tree-node-content-text').innerHTML.includes(val)) {
         n.classList.remove('s-hidden')
+        this._showParent(n)
       } else {
         n.classList.add('s-hidden')
       }

--- a/components/Grid/GridSettingTransfer.js
+++ b/components/Grid/GridSettingTransfer.js
@@ -96,10 +96,11 @@ class GridSettingTransfer extends Field {
                           },
                           children: {
                             component: 'Textbox',
-                            allowClear: false,
+                            allowClear: true,
                             _created: function () {
                               me.sourceSearch = this
                             },
+                            placeholder: '搜索所有列',
                             onValueChange: debounce(({ newValue }) => {
                               me._onSourceSearch(newValue)
                             }, 1000),
@@ -237,10 +238,11 @@ class GridSettingTransfer extends Field {
                           },
                           children: {
                             component: 'Textbox',
-                            allowClear: false,
+                            allowClear: true,
                             _created: function () {
                               me.targetSearch = this
                             },
+                            placeholder: '搜索已添加列',
                             onValueChange: debounce(({ newValue }) => {
                               me._onTargetSearch(newValue)
                             }, 1000),

--- a/components/Grid/GridSettingTransfer.js
+++ b/components/Grid/GridSettingTransfer.js
@@ -9,12 +9,13 @@ class GridSettingTransfer extends Field {
 
   _created() {
     super._created()
+
     this.warningFunc = null
     this.selectedKeys = []
-    this.selectedData = [
+    this.selectedData = this.props.allowFrozenCols ? [
       { title: '已冻结', field: 'isFrozen', isDivider: true },
       { title: '未冻结', field: 'isFree', isDivider: true },
-    ]
+    ] : []
   }
 
   _config() {
@@ -29,6 +30,7 @@ class GridSettingTransfer extends Field {
         initKeys = value
       }
     }
+
 
     this.setProps({
       control: {
@@ -248,6 +250,9 @@ class GridSettingTransfer extends Field {
                         sortable: {
                           filter: '.nom-grid-setting-group-title',
                           onMove: function (evt) {
+                            if (!me.props.allowFrozenCols) {
+                              return
+                            }
                             me.warningFunc = null
                             const toKey = evt.related.component.key
                             const siblings = evt.dragged.parentNode.childNodes
@@ -289,6 +294,7 @@ class GridSettingTransfer extends Field {
 
 
                             if (evt.related.innerHTML.includes('已冻结')) {
+
                               return 1
                             }
                           },
@@ -483,11 +489,14 @@ class GridSettingTransfer extends Field {
 
 
   _initAddNodes() {
+
     const nodes = this._getChildNodeKeys(this.sourceTree.getChildNodes())
 
     this._processChecked(nodes)
 
-    if (this.props.frozenCount) {
+
+    if (this.props.allowFrozenCols && this.props.frozenCount > 0) {
+
       this.selectedData = this.selectedData.filter((n) => {
         return n.field !== 'isFree'
       })
@@ -616,10 +625,10 @@ class GridSettingTransfer extends Field {
       text: '全选',
     })
     this.sourceTree.update({ data: this.props.data, nodeCheckable: { checkedNodeKeys: [] } })
-    this.selectedData = [
+    this.selectedData = this.props.allowFrozenCols ? [
       { title: '已冻结', field: 'isFrozen', isDivider: true },
       { title: '未冻结', field: 'isFree', isDivider: true },
-    ]
+    ] : []
     this.selectedKeys = []
     this.targetTree.update({
       data: this.selectedData,

--- a/components/Grid/GridSettingTransfer.js
+++ b/components/Grid/GridSettingTransfer.js
@@ -1,0 +1,620 @@
+import Component from '../Component/index'
+import Field from '../Field/index'
+import { debounce, isString } from '../util/index'
+
+class GridSettingTransfer extends Field {
+  constructor(props, ...mixins) {
+    super(Component.extendProps(GridSettingTransfer.defaults, props), ...mixins)
+  }
+
+  _created() {
+    super._created()
+    this.selectedKeys = []
+    this.selectedData = [
+      { title: '已冻结', field: 'isFrozen', isDivider: true },
+      { title: '未冻结', field: 'isFree', isDivider: true },
+    ]
+  }
+
+  _config() {
+    const me = this
+    const { data, dataFields, value, showSearch } = this.props
+
+    let initKeys = []
+    if (this.props.value) {
+      if (isString(value)) {
+        initKeys = [value]
+      } else {
+        initKeys = value
+      }
+    }
+
+    this.setProps({
+      control: {
+        children: {
+          component: 'Flex',
+          classes: {
+            'nom-grid-setting-transfer-container': true,
+          },
+          align: 'center',
+          gutter: 'medium',
+          cols: [
+            {
+              children: {
+                component: 'Layout',
+                classes: {
+                  'nom-grid-setting-transfer-box': true,
+                },
+                header: {
+                  children: {
+                    component: 'Flex',
+                    align: 'center',
+                    fit: true,
+
+                    cols: [
+                      {
+                        grow: true,
+                        children: {
+                          component: 'Button',
+                          text: '全选',
+                          size: 'small',
+                          ref: (c) => {
+                            me.checkAllBtn = c
+                          },
+                          type: 'text',
+                          onClick: ({ sender }) => {
+                            if (sender.props.text === '全选') {
+                              sender.update({
+                                text: '反选',
+                              })
+                              me.checkAll()
+                            } else {
+                              sender.update({
+                                text: '全选',
+                              })
+                              me.uncheckAll()
+                            }
+                          },
+                        },
+                      },
+                      {
+                        ref: (c) => {
+                          me.sourceCount = c
+                        },
+                        children: '',
+                      },
+                    ],
+                  },
+                },
+                body: {
+                  children: {
+                    component: 'Layout',
+                    header: showSearch
+                      ? {
+                          _created: function () {
+                            me.sourceSearchContainer = this
+                          },
+                          children: {
+                            component: 'Textbox',
+                            allowClear: false,
+                            _created: function () {
+                              me.sourceSearch = this
+                            },
+                            onValueChange: debounce(({ newValue }) => {
+                              me._onSourceSearch(newValue)
+                            }, 1000),
+                          },
+                        }
+                      : false,
+                    body: {
+                      children: {
+                        component: 'Tree',
+                        _created: function () {
+                          me.sourceTree = this
+                        },
+                        data: data,
+                        dataFields: dataFields,
+                        nodeSelectable: false,
+
+                        expandable: {
+                          byIndicator: true,
+                        },
+
+                        nodeCheckable: {
+                          cascade: true,
+                          checkedNodeKeys: initKeys,
+                          onCheckChange: () => {
+                            me._onSourceCheck()
+                          },
+                        },
+                        nodeDefaults: {
+                          onClick: ({ sender, event }) => {
+                            if (sender.checkboxRef.props.disabled) {
+                              return
+                            }
+                            if (sender.props.checked) {
+                              sender.uncheck()
+                            } else {
+                              sender.check()
+                            }
+                            event.stopPropagation()
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+                footer:
+                  this.props.pagination || this.props.footerRender
+                    ? {
+                        children: this.props.footerRender
+                          ? this.props.footerRender()
+                          : {
+                              component: 'Flex',
+                              fit: true,
+                              align: 'center',
+                              justify: 'end',
+                              cols: [
+                                {
+                                  children: {
+                                    component: 'Pager',
+                                    itemsSort: ['pages'],
+                                    totalCount: 50,
+                                    simple: true,
+                                    pageIndex: 1,
+                                    pageSize: 20,
+                                  },
+                                },
+                              ],
+                            },
+                      }
+                    : false,
+              },
+            },
+            {
+              gutter: 'small',
+              rows: [
+                {
+                  component: 'Button',
+                  size: 'small',
+                  icon: 'right',
+                  onClick: () => {
+                    me.addNodes()
+                  },
+                },
+                {
+                  component: 'Button',
+                  size: 'small',
+                  icon: 'left',
+                  onClick: () => {
+                    me.removeNodes()
+                  },
+                },
+              ],
+            },
+            {
+              children: {
+                component: 'Layout',
+                classes: {
+                  'nom-grid-setting-transfer-box': true,
+                },
+                header: {
+                  children: {
+                    component: 'Flex',
+                    align: 'center',
+                    fit: true,
+                    cols: [
+                      {
+                        grow: true,
+                        children: {
+                          component: 'List',
+                          items: [
+                            {
+                              children: '当前显示',
+                            },
+                            {
+                              ref: (c) => {
+                                me.targetCount = c
+                              },
+                              children: '',
+                            },
+                            {
+                              children: '项',
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+                body: {
+                  children: {
+                    component: 'Layout',
+                    header: showSearch
+                      ? {
+                          _created: function () {
+                            me.targetSearchContainer = this
+                          },
+                          children: {
+                            component: 'Textbox',
+                            allowClear: false,
+                            _created: function () {
+                              me.targetSearch = this
+                            },
+                            onValueChange: debounce(({ newValue }) => {
+                              me._onTargetSearch(newValue)
+                            }, 1000),
+                          },
+                        }
+                      : false,
+                    body: {
+                      children: {
+                        component: 'Tree',
+                        _created: function () {
+                          me.targetTree = this
+                        },
+                        data: [],
+                        flatData: me.props.displayAsTree,
+                        dataFields: { ...dataFields },
+                        nodeSelectable: false,
+                        sortable: {
+                          filter: '.nom-grid-setting-group-title',
+                          onMove: function (evt) {
+                            if (evt.dragged.querySelector('.nom-tree-nodes')) {
+                              const toKey = evt.related.component.key
+                              const siblings = evt.dragged.parentNode.childNodes
+                              let idx = 0
+                              let dividerIdx = 0
+                              siblings.forEach((n, i) => {
+                                if (n.component.key === toKey) {
+                                  idx = i
+                                }
+
+                                if (n.component.key === 'isFree') {
+                                  dividerIdx = i
+                                }
+                              })
+
+                              if (idx <= dividerIdx) {
+                                return false
+                              }
+                            }
+                            if (evt.related.innerHTML.includes('已冻结')) {
+                              return 1
+                            }
+                          },
+                          onEnd: function () {
+                            const keys = me._getCheckedChildNodeKeys(
+                              me.targetTree.getChildNodes(),
+                              true,
+                            )
+                            me.selectedData = keys.map((n) => {
+                              const { children, ...obj } = me.targetTree.getNode(n).props.data
+                              return obj
+                            })
+                          },
+                        },
+                        expandable: {
+                          byIndicator: true,
+                        },
+
+                        nodeCheckable: {
+                          cascadeCheckParent: false,
+                          cascadeCheckChildren: true,
+                          cascadeUncheckParent: true,
+                          cascadeUncheckChildren: true,
+                          onCheckChange: ({ sender }) => {
+                            me._onTargetCheck(sender)
+                          },
+                        },
+                        nodeDefaults: {
+                          onConfig: ({ inst }) => {
+                            if (inst.props.data.isDivider) {
+                              inst.setProps({
+                                disabled: true,
+                                classes: {
+                                  'nom-grid-setting-group-title': true,
+                                },
+                              })
+                            }
+                          },
+                          onClick: ({ sender, event }) => {
+                            if (sender.props.checked) {
+                              sender.uncheck()
+                            } else {
+                              sender.check()
+                            }
+                            event.stopPropagation()
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        },
+      },
+    })
+
+    super._config()
+  }
+
+  _rendered() {
+    if (this.firstRender) {
+      this._onSourceCheck()
+      this._onTargetCheck()
+      this.addNodes()
+    }
+  }
+
+  _getCheckedChildNodeKeys(nodes, ignoreCheck) {
+    const checkedNodes = []
+    nodes.forEach((node) => {
+      if (ignoreCheck || node.isChecked()) {
+        checkedNodes.push(node.key)
+      }
+
+      if (node.getChildNodes().length) {
+        Array.prototype.push.apply(
+          checkedNodes,
+          this._getCheckedChildNodeKeys(node.getChildNodes(), ignoreCheck),
+        )
+      }
+    })
+
+    return checkedNodes
+  }
+
+  _onSourceSearch(val) {
+    this.sourceTree.element.querySelectorAll('.nom-tree-node').forEach((n) => {
+      if (!val || n.querySelector('.nom-tree-node-content-text').innerHTML.includes(val)) {
+        n.classList.remove('s-hidden')
+      } else {
+        n.classList.add('s-hidden')
+      }
+    })
+  }
+
+  _onTargetSearch(val) {
+    this.targetTree.element.querySelectorAll('.nom-tree-node').forEach((n) => {
+      if (!val || n.querySelector('.nom-tree-node-content-text').innerHTML.includes(val)) {
+        n.classList.remove('s-hidden')
+      } else {
+        n.classList.add('s-hidden')
+      }
+    })
+  }
+
+  _onSourceCheck() {
+    const u = this.sourceTree.getCheckedNodeKeys().length
+    const d = this._getCheckedChildNodeKeys(this.sourceTree.getChildNodes(), true).length
+    this.sourceCount.update({
+      children: `${u}/${d}项`,
+    })
+  }
+
+  _onTargetCheck(node) {
+    if (node && node.parentNode && node.parentNode.getChildNodes().length === 1) {
+      if (node.props.checked === true) {
+        node.parentNode.check({ fromChildren: true })
+      } else {
+        node.parentNode.uncheck({ skipChildren: true })
+      }
+    }
+
+    const d = this._getCheckedChildNodeKeys(this.targetTree.getChildNodes(), true).length - 2
+    this.targetCount.update({
+      children: `${d}`,
+    })
+  }
+
+  _disableNode(node) {
+    node.checkboxRef.disable()
+    node.props.disabled = true
+  }
+
+  _enableNode(node) {
+    node.checkboxRef.enable()
+    node.props.disabled = false
+  }
+
+  _hideNode(node) {
+    node.element.classList.add('s-hidden')
+  }
+
+  _showNode(node) {
+    node.element.classList.remove('s-hidden')
+  }
+
+  _processChecked(nodes) {
+    for (let i = 0; i < nodes.length; i++) {
+      const node = this.sourceTree.getNode(nodes[i])
+
+      if (!node.isChecked()) {
+        continue
+      }
+
+      // 添加目标项
+      if (!node.props.data.disabled && !this.selectedKeys.includes(node.key)) {
+        this.selectedKeys.push(node.key)
+        if (node.parentNode) {
+          node.props.data.parentKey = node.parentNode.key
+        }
+
+        this.selectedData.push(node.props.data)
+      }
+
+      // 禁用源项
+
+      let hideFlag = true
+
+      if (node.props.data.children) {
+        const cNodes = node.getChildNodes()
+        for (let x = 0; x < cNodes.length; x++) {
+          if (!cNodes[x].isChecked()) {
+            hideFlag = false
+          }
+        }
+      }
+
+      if (this.props.hideOnSelect && hideFlag) {
+        this._hideNode(node)
+      }
+
+      this._disableNode(node)
+    }
+  }
+
+  addNodes() {
+    const nodes = this._getCheckedChildNodeKeys(this.sourceTree.getChildNodes())
+
+    this._processChecked(nodes)
+
+    if (this.props.frozenCount) {
+      this.selectedData = this.selectedData.filter((n) => {
+        return n.field !== 'isFree'
+      })
+      this.selectedData.splice(this.props.frozenCount + 1, 0, {
+        title: '未冻结',
+        field: 'isFree',
+        isDivider: true,
+      })
+    }
+    this.targetTree.update({
+      data: this.selectedData,
+    })
+    this._onSourceCheck()
+    this._onTargetCheck()
+    this.props.onChange && this._callHandler(this.props.onChange, { newValue: this.getValue() })
+  }
+
+  removeNodes() {
+    const targetNodes = this.targetTree.getChildNodes()
+    const nodes = this._getCheckedChildNodeKeys(
+      targetNodes.filter((n) => {
+        return n !== 'isFrozen' || n !== 'isFree'
+      }),
+    )
+    if (!nodes.length) {
+      return
+    }
+
+    this.selectedKeys = this._getCheckedChildNodeKeys(targetNodes, true)
+
+    this._removeItem(nodes)
+
+    this.selectedData = this.selectedData.filter((n) => {
+      return this.selectedKeys.includes(n.field)
+    })
+
+    this._onSourceCheck()
+    this._onTargetCheck()
+    this.props.onChange && this._callHandler(this.props.onChange, { newValue: this.getValue() })
+  }
+
+  _removeItem(nodes) {
+    for (let i = 0; i < nodes.length; i++) {
+      const nodeKey = nodes[i]
+      this.selectedKeys = this.selectedKeys.filter((n) => {
+        return n !== nodeKey
+      })
+
+      const sourceItem = this.sourceTree.getNode(nodeKey)
+
+      if (this.props.hideOnSelect) {
+        this._showNode(sourceItem)
+      }
+      this._enableNode(sourceItem)
+      sourceItem.uncheck()
+
+      if (this.targetTree.getNode(nodeKey) && this.targetTree.getNode(nodeKey).props) {
+        this.targetTree.getNode(nodeKey).remove()
+      }
+    }
+  }
+
+  checkAll() {
+    this.sourceTree.checkAllNodes()
+  }
+
+  uncheckAll() {
+    this.sourceTree.uncheckAllNodes({ ignoreDisabled: true })
+  }
+
+  clear() {
+    this.checkAllBtn.update({
+      text: '全选',
+    })
+    this.sourceTree.update({ data: this.props.data })
+    this.selectedData = [
+      { title: '已冻结', field: 'isFrozen', isDivider: true },
+      { title: '未冻结', field: 'isFree', isDivider: true },
+    ]
+    this.selectedKeys = []
+    this.targetTree.update({
+      data: this.selectedData,
+    })
+    this._onSourceCheck()
+    this._onTargetCheck()
+    this.props.onChange && this._callHandler(this.props.onChange, { newValue: this.getValue() })
+  }
+
+  getValue() {
+    const keys = this._getCheckedChildNodeKeys(this.targetTree.getChildNodes(), true)
+    if (!keys || !keys.length) {
+      return null
+    }
+    return keys
+  }
+
+  getData() {
+    return this.sourceTree.getData()
+  }
+
+  getFrozenCount() {
+    let num = 0
+    this.targetTree.getData().forEach((n, i) => {
+      if (n.field === 'isFree') {
+        num = i - 1
+      }
+    })
+
+    return num
+  }
+
+  getSelectedData() {
+    function mapTree(arr) {
+      return arr.map((n) => {
+        const obj = n.props.data
+        const c = n.getChildNodes()
+        if (c.length) {
+          obj.children = mapTree(c)
+        }
+        return obj
+      })
+    }
+
+    const data = mapTree(this.targetTree.getChildNodes()).filter((n) => {
+      return n.isDivider !== true
+    })
+
+    return data
+  }
+}
+
+GridSettingTransfer.defaults = {
+  data: [],
+  value: null,
+  hideOnSelect: false,
+  itemRender: null,
+  showSearch: true,
+  frozenCount: null,
+  displayAsTree: true,
+  dataFields: { key: 'field', text: 'title', children: 'children', parentKey: 'parentKey' },
+}
+
+Component.register(GridSettingTransfer)
+
+export default GridSettingTransfer

--- a/components/Grid/GridSettingTransfer.js
+++ b/components/Grid/GridSettingTransfer.js
@@ -319,7 +319,6 @@ class GridSettingTransfer extends Field {
                                 classes: {
                                   'nom-grid-setting-group-title': true,
                                 },
-                                tooltip: inst.props.data.field === 'isFrozen' ? '不支持冻结多级表头' : null
                               })
                             }
 

--- a/components/Grid/GridSettingTransfer.js
+++ b/components/Grid/GridSettingTransfer.js
@@ -37,7 +37,7 @@ class GridSettingTransfer extends Field {
             'nom-grid-setting-transfer-container': true,
           },
           align: 'center',
-          gutter: 'medium',
+          gutter: 'large',
           cols: [
             {
               children: {
@@ -91,21 +91,21 @@ class GridSettingTransfer extends Field {
                     component: 'Layout',
                     header: showSearch
                       ? {
+                        _created: function () {
+                          me.sourceSearchContainer = this
+                        },
+                        children: {
+                          component: 'Textbox',
+                          allowClear: true,
                           _created: function () {
-                            me.sourceSearchContainer = this
+                            me.sourceSearch = this
                           },
-                          children: {
-                            component: 'Textbox',
-                            allowClear: true,
-                            _created: function () {
-                              me.sourceSearch = this
-                            },
-                            placeholder: '搜索所有列',
-                            onValueChange: debounce(({ newValue }) => {
-                              me._onSourceSearch(newValue)
-                            }, 1000),
-                          },
-                        }
+                          placeholder: '搜索所有列',
+                          onValueChange: debounce(({ newValue }) => {
+                            me._onSourceSearch(newValue)
+                          }, 1000),
+                        },
+                      }
                       : false,
                     body: {
                       children: {
@@ -124,8 +124,10 @@ class GridSettingTransfer extends Field {
                         nodeCheckable: {
                           cascade: true,
                           checkedNodeKeys: initKeys,
-                          onCheckChange: () => {
-                            me._onSourceCheck()
+                          onCheckChange: ({ sender }) => {
+
+                            me._setSourceCount()
+                            me._handleCheckNode(sender)
                           },
                         },
                         nodeDefaults: {
@@ -148,51 +150,51 @@ class GridSettingTransfer extends Field {
                 footer:
                   this.props.pagination || this.props.footerRender
                     ? {
-                        children: this.props.footerRender
-                          ? this.props.footerRender()
-                          : {
-                              component: 'Flex',
-                              fit: true,
-                              align: 'center',
-                              justify: 'end',
-                              cols: [
-                                {
-                                  children: {
-                                    component: 'Pager',
-                                    itemsSort: ['pages'],
-                                    totalCount: 50,
-                                    simple: true,
-                                    pageIndex: 1,
-                                    pageSize: 20,
-                                  },
-                                },
-                              ],
+                      children: this.props.footerRender
+                        ? this.props.footerRender()
+                        : {
+                          component: 'Flex',
+                          fit: true,
+                          align: 'center',
+                          justify: 'end',
+                          cols: [
+                            {
+                              children: {
+                                component: 'Pager',
+                                itemsSort: ['pages'],
+                                totalCount: 50,
+                                simple: true,
+                                pageIndex: 1,
+                                pageSize: 20,
+                              },
                             },
-                      }
+                          ],
+                        },
+                    }
                     : false,
               },
             },
-            {
-              gutter: 'small',
-              rows: [
-                {
-                  component: 'Button',
-                  size: 'small',
-                  icon: 'right',
-                  onClick: () => {
-                    me.addNodes()
-                  },
-                },
-                {
-                  component: 'Button',
-                  size: 'small',
-                  icon: 'left',
-                  onClick: () => {
-                    me.removeNodes()
-                  },
-                },
-              ],
-            },
+            // {
+            //   gutter: 'small',
+            //   rows: [
+            //     {
+            //       component: 'Button',
+            //       size: 'small',
+            //       icon: 'right',
+            //       onClick: () => {
+            //         me._initAddNodes()
+            //       },
+            //     },
+            //     {
+            //       component: 'Button',
+            //       size: 'small',
+            //       icon: 'left',
+            //       onClick: () => {
+            //         me.removeNodes()
+            //       },
+            //     },
+            //   ],
+            // },
             {
               children: {
                 component: 'Layout',
@@ -233,21 +235,21 @@ class GridSettingTransfer extends Field {
                     component: 'Layout',
                     header: showSearch
                       ? {
+                        _created: function () {
+                          me.targetSearchContainer = this
+                        },
+                        children: {
+                          component: 'Textbox',
+                          allowClear: true,
                           _created: function () {
-                            me.targetSearchContainer = this
+                            me.targetSearch = this
                           },
-                          children: {
-                            component: 'Textbox',
-                            allowClear: true,
-                            _created: function () {
-                              me.targetSearch = this
-                            },
-                            placeholder: '搜索已添加列',
-                            onValueChange: debounce(({ newValue }) => {
-                              me._onTargetSearch(newValue)
-                            }, 1000),
-                          },
-                        }
+                          placeholder: '搜索已添加列',
+                          onValueChange: debounce(({ newValue }) => {
+                            me._onTargetSearch(newValue)
+                          }, 1000),
+                        },
+                      }
                       : false,
                     body: {
                       children: {
@@ -299,16 +301,17 @@ class GridSettingTransfer extends Field {
                         expandable: {
                           byIndicator: true,
                         },
+                        nodeCheckable: false,
 
-                        nodeCheckable: {
-                          cascadeCheckParent: false,
-                          cascadeCheckChildren: true,
-                          cascadeUncheckParent: true,
-                          cascadeUncheckChildren: true,
-                          onCheckChange: ({ sender }) => {
-                            me._onTargetCheck(sender)
-                          },
-                        },
+                        // nodeCheckable: {
+                        //   cascadeCheckParent: false,
+                        //   cascadeCheckChildren: true,
+                        //   cascadeUncheckParent: true,
+                        //   cascadeUncheckChildren: true,
+                        //   onCheckChange: ({ sender }) => {
+                        //     me._setTargetCount(sender)
+                        //   },
+                        // },
                         nodeDefaults: {
                           onConfig: ({ inst }) => {
                             if (inst.props.data.isDivider) {
@@ -320,14 +323,14 @@ class GridSettingTransfer extends Field {
                               })
                             }
                           },
-                          onClick: ({ sender, event }) => {
-                            if (sender.props.checked) {
-                              sender.uncheck()
-                            } else {
-                              sender.check()
-                            }
-                            event.stopPropagation()
-                          },
+                          // onClick: ({ sender, event }) => {
+                          //   if (sender.props.checked) {
+                          //     sender.uncheck()
+                          //   } else {
+                          //     sender.check()
+                          //   }
+                          //   event.stopPropagation()
+                          // },
                         },
                       },
                     },
@@ -345,9 +348,9 @@ class GridSettingTransfer extends Field {
 
   _rendered() {
     if (this.firstRender) {
-      this._onSourceCheck()
-      this._onTargetCheck()
-      this.addNodes()
+      this._setSourceCount()
+      this._setTargetCount()
+      this._initAddNodes()
     }
   }
 
@@ -399,7 +402,7 @@ class GridSettingTransfer extends Field {
     })
   }
 
-  _onSourceCheck() {
+  _setSourceCount() {
     const u = this.sourceTree.getCheckedNodeKeys().length
     const d = this._getCheckedChildNodeKeys(this.sourceTree.getChildNodes(), true).length
     this.sourceCount.update({
@@ -407,7 +410,7 @@ class GridSettingTransfer extends Field {
     })
   }
 
-  _onTargetCheck(node) {
+  _setTargetCount(node) {
     if (node && node.parentNode && node.parentNode.getChildNodes().length === 1) {
       if (node.props.checked === true) {
         node.parentNode.check({ fromChildren: true })
@@ -445,6 +448,14 @@ class GridSettingTransfer extends Field {
       const node = this.sourceTree.getNode(nodes[i])
 
       if (!node.isChecked()) {
+        // if (this.selectedKeys.includes(node.key)) {
+        //   this.selectedKeys = this.selectedKeys.filter(n => {
+        //     return n !== node.key
+        //   })
+        //   this.selectedData = this.selectedData.filter(n => {
+        //     return n[this.props.dataFields.key] !== node.props.data[this.props.dataFields.key]
+        //   })
+        // }
         continue
       }
 
@@ -458,28 +469,33 @@ class GridSettingTransfer extends Field {
         this.selectedData.push(node.props.data)
       }
 
-      // 禁用源项
 
-      let hideFlag = true
 
-      if (node.props.data.children) {
-        const cNodes = node.getChildNodes()
-        for (let x = 0; x < cNodes.length; x++) {
-          if (!cNodes[x].isChecked()) {
-            hideFlag = false
-          }
-        }
-      }
+      // // 禁用源项
 
-      if (this.props.hideOnSelect && hideFlag) {
-        this._hideNode(node)
-      }
+      // let hideFlag = true
 
-      this._disableNode(node)
+      // if (node.props.data.children) {
+      //   const cNodes = node.getChildNodes()
+      //   for (let x = 0; x < cNodes.length; x++) {
+      //     if (!cNodes[x].isChecked()) {
+      //       hideFlag = false
+      //     }
+      //   }
+      // }
+
+      // if (this.props.hideOnSelect && hideFlag) {
+      //   this._hideNode(node)
+      // }
+
+      // this._disableNode(node)
     }
+
+
   }
 
-  addNodes() {
+
+  _initAddNodes() {
     const nodes = this._getCheckedChildNodeKeys(this.sourceTree.getChildNodes())
 
     this._processChecked(nodes)
@@ -497,17 +513,17 @@ class GridSettingTransfer extends Field {
     this.targetTree.update({
       data: this.selectedData,
     })
-    this._onSourceCheck()
-    this._onTargetCheck()
+    this._setSourceCount()
+    this._setTargetCount()
     this.props.onChange && this._callHandler(this.props.onChange, { newValue: this.getValue() })
   }
 
-  removeNodes() {
+  removeNode() {
     const targetNodes = this.targetTree.getChildNodes()
     const nodes = this._getCheckedChildNodeKeys(
       targetNodes.filter((n) => {
         return n !== 'isFrozen' || n !== 'isFree'
-      }),
+      })
     )
     if (!nodes.length) {
       return
@@ -521,10 +537,39 @@ class GridSettingTransfer extends Field {
       return this.selectedKeys.includes(n.field)
     })
 
-    this._onSourceCheck()
-    this._onTargetCheck()
+    this._setSourceCount()
+    this._setTargetCount()
     this.props.onChange && this._callHandler(this.props.onChange, { newValue: this.getValue() })
   }
+
+
+  _handleCheckNode(node) {
+
+    if (node.props.checked) {
+      // 添加目标项
+      if (!this.selectedKeys.includes(node.key)) {
+        this.selectedKeys.push(node.key)
+        if (node.parentNode) {
+          node.props.data.parentKey = node.parentNode.key
+        }
+        this.selectedData.push(node.props.data)
+      }
+
+    }
+    else if (this.selectedKeys.includes(node.key)) {
+      this.selectedKeys = this.selectedKeys.filter(n => { return n !== node.key })
+      this.selectedData = this.selectedData.filter(n => { return n[this.props.dataFields.key] !== node.props.data[this.props.dataFields.key] })
+    }
+
+    this.targetTree.update({
+      data: this.selectedData,
+    })
+
+    this._setSourceCount()
+    this._setTargetCount()
+    this.props.onChange && this._callHandler(this.props.onChange, { newValue: this.getValue() })
+  }
+
 
   _removeItem(nodes) {
     for (let i = 0; i < nodes.length; i++) {
@@ -568,8 +613,8 @@ class GridSettingTransfer extends Field {
     this.targetTree.update({
       data: this.selectedData,
     })
-    this._onSourceCheck()
-    this._onTargetCheck()
+    this._setSourceCount()
+    this._setTargetCount()
     this.props.onChange && this._callHandler(this.props.onChange, { newValue: this.getValue() })
   }
 

--- a/components/Grid/demos/frozen-header.js
+++ b/components/Grid/demos/frozen-header.js
@@ -9,6 +9,7 @@ define([], function () {
             component: 'Grid',
             bordered: true,
             line: 'both',
+            allowFrozenCols: true,
             columns: [
               {
                 field: 'name',
@@ -42,7 +43,6 @@ define([], function () {
             frozenHeader: true,
             frozenLeftCols: 1,
             frozenRightCols: 0,
-            // allowFrozenCols: true,
             columnsCustomizable: true,
             attrs: {
               style: {

--- a/components/Grid/demos/pin.js
+++ b/components/Grid/demos/pin.js
@@ -6,9 +6,12 @@ define([], function () {
       return {
         component: 'Grid',
         key: 'grid-pin-demo',
-        allowFrozenCols: true,
+        allowFrozenCols: {
+          showPinner: true,
+        },
         frozenLeftCols: 1,
         rowCheckable: true,
+        frozenLimit: 2,
         columnsCustomizable: {
           cache: true,
         },

--- a/components/Grid/index.md
+++ b/components/Grid/index.md
@@ -39,7 +39,8 @@
 | frozenHeader | 冻结表头（注意配置列宽, 见下面的`注意事项`） | `boolean` | `false` |
 | frozenLeftCols | 指定冻结左侧多少列 | `number` | - |
 | frozenRightCols | 指定冻结右侧多少列 | `number` | - |
-| allowFrozenCols | 是否允许用户手动固定列(有多级表头时无效) | `boolean` | `false` |
+| allowFrozenCols | 是否允许用户手动固定列(有多级表头时无效) | `{showPinner}`\|`boolean` | `true` |
+| frozenLimit | 最大可固定在左侧的列数 | `number` | 5      |
 | keyField | 表格行数据的主键字段 | `string` | `id` |
 | rowCheckable | 表格行是否可选择 | `object` \| `boolean` |  |
 | rowExpandable | 表格行是否可展开 | `object` \| `boolean` |  |
@@ -141,6 +142,14 @@
     ]
 }
 ```
+
+### allowFrozenCols
+
+手动固定列配置
+
+| 参数     | 说明       | 类型                  | 默认值 |
+| -------- | ---------- | --------------------- | ------ |
+| showPinner | 是否在表头显示固定按钮 | `boolean` | false      |
 
 ### rowSelectable
 

--- a/components/Grid/styles/index.less
+++ b/components/Grid/styles/index.less
@@ -200,6 +200,7 @@
       border:1px solid var(--nom-border-color);
       width:230px;
       height: calc(100vh - 300px);
+      max-height: 500px;
       .nom-tree-node-expandable-indicator {
         width: 24px;
       }

--- a/components/Grid/styles/index.less
+++ b/components/Grid/styles/index.less
@@ -249,6 +249,9 @@
 
   .nom-grid-setting-target-node {
     .nom-tree-node-content {
+      .p-type-times {
+        color: var(--nom-text-color-muted);
+      }
       &:not(:hover) {
         .nom-tree-node-content-tools {
           visibility: hidden;

--- a/components/Grid/styles/index.less
+++ b/components/Grid/styles/index.less
@@ -173,20 +173,79 @@
 .nom-grid-setting-panel {
   min-width: 300px;
 
-  .nom-tree {
-    .nom-tree-node-content {
-      position: relative;
-      top: 0;
-      transition: all 0.25s;
+  // .nom-tree {
+  //   .nom-tree-node-content {
+  //     position: relative;
+  //     top: 0;
+  //     transition: all 0.25s;
 
-      &:hover {
-        top: -2px;
-        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
-      }
-    }
-  }
+  //     &:hover {
+  //       top: -2px;
+  //       box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
+  //     }
+  //   }
+  // }
 }
 
 .nom-grid-setting-drag {
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+}
+
+.nom-grid-setting-transfer {
+  .nom-grid-setting-transfer-container {
+    
+   
+    .nom-grid-setting-transfer-box {
+      border-radius: var(--nom-border-radius);
+      border:1px solid var(--nom-border-color);
+      width:230px;
+      height: calc(100vh - 300px);
+      .nom-tree-node-expandable-indicator {
+        width: 24px;
+      }
+      >.nom-layout-header {
+        height: 40px;
+        padding:0 10px;
+        .nom-checkbox {
+          >.nom-field-content {
+            line-height: 100%;
+          }
+        }
+      }
+      >.nom-layout-body {
+        .nom-layout-header {
+          height: 42px;
+          border-bottom: none;
+        }
+      }
+      >.nom-layout-footer {
+        height: 40px;
+        min-height: 40px;
+        padding:0 10px;
+      }
+    }
+  }
+
+  .nom-tree-node-content {
+    position: relative;
+    >.nom-grid-setting-item-pin {
+      position: absolute;
+      top:5px;
+      right:5px;
+    }
+    
+  }
+
+  .nom-grid-setting-group-title {
+    
+      .nom-tree-node-content {
+        >.nom-icon,>.nom-tree-node-checkbox {
+          display: none;
+        }
+        >.nom-tree-node-content-text {
+          color:var(--nom-text-color-muted);
+          padding-left: 1rem;
+        }
+      }
+  }
 }

--- a/components/Grid/styles/index.less
+++ b/components/Grid/styles/index.less
@@ -193,12 +193,10 @@
 
 .nom-grid-setting-transfer {
   .nom-grid-setting-transfer-container {
-    
-   
     .nom-grid-setting-transfer-box {
-      border-radius: var(--nom-border-radius);
-      border:1px solid var(--nom-border-color);
       width:240px;
+      border:1px solid var(--nom-border-color);
+      border-radius: var(--nom-border-radius);
       height: calc(100vh - 300px);
       max-height: 500px;
       .nom-tree-node-expandable-indicator {
@@ -238,15 +236,27 @@
   }
 
   .nom-grid-setting-group-title {
-    
       .nom-tree-node-content {
         >.nom-icon,>.nom-tree-node-checkbox {
           display: none;
         }
         >.nom-tree-node-content-text {
-          color:var(--nom-text-color-muted);
           padding-left: 1rem;
+          color:var(--nom-text-color-muted);
         }
       }
+  }
+
+  .nom-grid-setting-target-node {
+    .nom-tree-node-content {
+      &:not(:hover) {
+        .nom-tree-node-content-tools {
+          visibility: hidden;
+        }
+      }
+      >.nom-tree-node-content-text {
+        flex-grow: 1;
+      }
+    }
   }
 }

--- a/components/Grid/styles/index.less
+++ b/components/Grid/styles/index.less
@@ -198,7 +198,7 @@
     .nom-grid-setting-transfer-box {
       border-radius: var(--nom-border-radius);
       border:1px solid var(--nom-border-color);
-      width:230px;
+      width:240px;
       height: calc(100vh - 300px);
       max-height: 500px;
       .nom-tree-node-expandable-indicator {

--- a/components/Table/Th.js
+++ b/components/Table/Th.js
@@ -24,6 +24,7 @@ class Th extends Component {
 
   _config() {
     const that = this
+
     this.filterValue = this.table.hasGrid ? this.table.grid.filter[this.props.column.field] : null
 
     const columnAlign = this.table.hasGrid ? this.table.grid.props.columnAlign : 'left'
@@ -79,121 +80,122 @@ class Th extends Component {
     let children = [
       headerProps,
       this.props.column.sortable &&
-        this.props.column.colSpan > 0 && {
-          component: 'Icon',
-          classes: {
-            'nom-table-sort-handler': true,
-          },
-          type: sortIcon,
-          onClick: function () {
-            that.onSortChange()
+      this.props.column.colSpan > 0 && {
+        component: 'Icon',
+        classes: {
+          'nom-table-sort-handler': true,
+        },
+        type: sortIcon,
+        onClick: function () {
+          that.onSortChange()
+        },
+      },
+      this.props.column.filter &&
+      this.props.column.colSpan > 0 && {
+        component: 'Icon',
+        type: 'filter',
+        ref: (c) => {
+          this.filterBtn = c
+        },
+        classes: {
+          'nom-table-filter-handler': true,
+        },
+        attrs: {
+          style: {
+            cursor: 'pointer',
           },
         },
-      this.props.column.filter &&
-        this.props.column.colSpan > 0 && {
-          component: 'Icon',
-          type: 'filter',
+        tooltip: this.filterValue
+          ? this.table.grid.filterValueText[this.props.column.field]
+          : null,
+        popup: {
+          align: 'bottom right',
           ref: (c) => {
-            this.filterBtn = c
+            this.filterPopup = c
           },
-          classes: {
-            'nom-table-filter-handler': true,
+          onShow: () => {
+            that.filterGroup && that.filterGroup.setValue(that.filterValue)
           },
-          attrs: {
-            style: {
-              cursor: 'pointer',
-            },
-          },
-          tooltip: this.filterValue
-            ? this.table.grid.filterValueText[this.props.column.field]
-            : null,
-          popup: {
-            align: 'bottom right',
-            ref: (c) => {
-              this.filterPopup = c
-            },
-            onShow: () => {
-              that.filterGroup && that.filterGroup.setValue(that.filterValue)
-            },
-            children: {
-              attrs: {
-                style: {
-                  padding: '10px',
-                  'min-width': '180px',
-                  'max-width': '250px',
-                },
+          children: {
+            attrs: {
+              style: {
+                padding: '10px',
+                'min-width': '180px',
+                'max-width': '250px',
               },
-              children: [
-                {
-                  component: 'Group',
-                  ref: (c) => {
-                    this.filterGroup = c
-                  },
+            },
+            children: [
+              {
+                component: 'Group',
+                ref: (c) => {
+                  this.filterGroup = c
+                },
 
-                  fields: [
+                fields: [
+                  {
+                    ...(isFunction(that.props.column.filter)
+                      ? that.props.column.filter()
+                      : that.props.column.filter),
+                    name: that.props.column.field,
+                  },
+                ],
+              },
+              {
+                attrs: {
+                  style: {
+                    'text-align': 'right',
+                    padding: '0 10px',
+                  },
+                },
+                children: {
+                  component: 'Cols',
+                  justify: 'end',
+                  gutter: 'sm',
+                  items: [
                     {
-                      ...(isFunction(that.props.column.filter)
-                        ? that.props.column.filter()
-                        : that.props.column.filter),
-                      name: that.props.column.field,
+                      component: 'Button',
+                      text: '确定',
+                      size: 'small',
+                      onClick: () => {
+                        this.onFilterChange()
+                      },
+                    },
+                    {
+                      component: 'Button',
+                      text: '重置',
+                      size: 'small',
+                      onClick: () => {
+                        this.onFilterReset()
+                      },
                     },
                   ],
                 },
-                {
-                  attrs: {
-                    style: {
-                      'text-align': 'right',
-                      padding: '0 10px',
-                    },
-                  },
-                  children: {
-                    component: 'Cols',
-                    justify: 'end',
-                    gutter: 'sm',
-                    items: [
-                      {
-                        component: 'Button',
-                        text: '确定',
-                        size: 'small',
-                        onClick: () => {
-                          this.onFilterChange()
-                        },
-                      },
-                      {
-                        component: 'Button',
-                        text: '重置',
-                        size: 'small',
-                        onClick: () => {
-                          this.onFilterReset()
-                        },
-                      },
-                    ],
-                  },
-                },
-              ],
-            },
+              },
+            ],
           },
         },
+      },
       that.table.hasGrid &&
-        that.table.grid.props.allowFrozenCols &&
-        !this.table.hasMultipleThead &&
-        !(this.props.column.width && this.props.column.width > 600) &&
-        !this.props.column.isChecker &&
-        !this.props.column.isTreeMark &&
-        this.props.column.fixed !== 'right' &&
-        this.props.column.frozenable !== false && {
-          component: 'Icon',
-          type: this.props.column.fixed ? 'pin-fill' : 'pin',
-          attrs: {
-            title: this.props.column.fixed ? '取消固定' : '固定列',
-          },
-          classes: {
-            'nom-table-pin-handler': true,
-          },
-          onClick: function () {
-            that.table.grid.handlePinClick(that.props.column)
-          },
+      that.table.grid.props.allowFrozenCols &&
+      that.table.grid.props.allowFrozenCols.showPinner &&
+      !this.table.hasMultipleThead &&
+      !(this.props.column.width && this.props.column.width > 600) &&
+      !this.props.column.isChecker &&
+      !this.props.column.isTreeMark &&
+      this.props.column.fixed !== 'right' &&
+      this.props.column.frozenable !== false && {
+        component: 'Icon',
+        type: this.props.column.fixed ? 'pin-fill' : 'pin',
+        attrs: {
+          title: this.props.column.fixed ? '取消固定' : '固定列',
         },
+        classes: {
+          'nom-table-pin-handler': true,
+        },
+        onClick: function () {
+          that.table.grid.handlePinClick(that.props.column)
+        },
+      },
       that.resizable && {
         // component: 'Icon',
         ref: (c) => {

--- a/components/Tree/TreeNode.js
+++ b/components/Tree/TreeNode.js
@@ -57,7 +57,9 @@ class TreeNode extends Component {
 
     if (this.tree.props.nodeCheckable) {
       this.setProps({
-        checked: this.tree.checkedNodeKeysHash[this.key] === true,
+        checked: this.firstRender
+          ? this.tree.checkedNodeKeysHash[this.key] === true
+          : this.props.checked === true || this.tree.checkedNodeKeysHash[this.key] === true,
       })
     }
   }
@@ -213,6 +215,38 @@ class TreeNode extends Component {
 
   unselect() {
     this.content.unselect()
+  }
+
+  disable() {
+    this.update({
+      data: {
+        disabled: true,
+      },
+    })
+  }
+
+  enable() {
+    this.update({
+      data: {
+        disabled: false,
+      },
+    })
+  }
+
+  hide() {
+    this.update({
+      data: {
+        hidden: true,
+      },
+    })
+  }
+
+  show() {
+    this.update({
+      data: {
+        hidden: false,
+      },
+    })
   }
 }
 TreeNode.defaults = {

--- a/components/Tree/TreeNodeContent.js
+++ b/components/Tree/TreeNodeContent.js
@@ -100,25 +100,25 @@ class TreeNodeContent extends Component {
     this.setProps({
       children: [
         this.tree.props.sortable &&
-          this.tree.props.sortable.showHandler && {
-            attrs: {
-              style: {
-                paddingLeft: '1rem',
-              },
-            },
-            children: {
-              component: 'Icon',
-              type: 'swap',
-              classes: { 'nom-tree-drag-handler': true },
+        this.tree.props.sortable.showHandler && {
+          attrs: {
+            style: {
+              paddingLeft: '1rem',
             },
           },
+          children: {
+            component: 'Icon',
+            type: 'swap',
+            classes: { 'nom-tree-drag-handler': true },
+          },
+        },
         this.getExpandableIndicatorProps(expanded),
         nodeCheckable && this._getCheckbox(),
         icon &&
-          Component.extendProps(
-            { classes: { 'nom-tree-node-content-icon': true } },
-            Component.normalizeIconProps(icon),
-          ),
+        Component.extendProps(
+          { classes: { 'nom-tree-node-content-icon': true } },
+          Component.normalizeIconProps(icon),
+        ),
         Component.extendProps(
           {
             tag: 'span',
@@ -130,29 +130,29 @@ class TreeNodeContent extends Component {
           Component.normalizeTemplateProps(text),
         ),
         tools &&
-          (isNewToolProp
-            ? {
-                classes: {
-                  'nom-tree-node-content-tools': true,
-                  'nom-tree-node-content-tools-flex': true,
-                  'nom-tree-node-content-tools-hover': !!tools.hover,
-                },
-                children: {
-                  component: 'Flex',
-                  justify: toolProps.justify,
-                  fit: true,
-                  cols: toolProps.items,
-                },
-              }
-            : Component.extendProps(
-                {
-                  classes: {
-                    'nom-tree-node-content-tools': true,
-                    'nom-tree-node-content-tools-hover': !!tools.hover,
-                  },
-                },
-                toolProps,
-              )),
+        (isNewToolProp
+          ? {
+            classes: {
+              'nom-tree-node-content-tools': true,
+              'nom-tree-node-content-tools-flex': true,
+              'nom-tree-node-content-tools-hover': !!tools.hover,
+            },
+            children: {
+              component: 'Flex',
+              justify: toolProps.justify,
+              fit: true,
+              cols: toolProps.items,
+            },
+          }
+          : Component.extendProps(
+            {
+              classes: {
+                'nom-tree-node-content-tools': true,
+                'nom-tree-node-content-tools-hover': !!tools.hover,
+              },
+            },
+            toolProps,
+          )),
       ],
       onClick: () => {
         this.tree._onNodeClick({ node: this.node })

--- a/components/Tree/TreeNodeContent.js
+++ b/components/Tree/TreeNodeContent.js
@@ -190,7 +190,11 @@ class TreeNodeContent extends Component {
       _created: (inst) => {
         this.node.checkboxRef = inst
       },
-      value: this.tree.checkedNodeKeysHash[this.node.key] === true,
+      onClick: ({ event }) => {
+        event.stopPropagation()
+      },
+      value:
+        this.node.props.checked === true || this.tree.checkedNodeKeysHash[this.node.key] === true,
       onValueChange: ({ newValue }) => {
         if (newValue === true) {
           this.node.check({ checkCheckbox: false })

--- a/components/Tree/TreeNodes.js
+++ b/components/Tree/TreeNodes.js
@@ -60,18 +60,35 @@ class TreeNodes extends Component {
   _rendered() {
     const { sortable } = this.tree.props
     if (sortable !== false) {
-      new Sortable(this.element, {
-        group: this.key,
-        animation: 150,
-        fallbackOnBody: true,
-        swapThreshold: 0.65,
-        handle:
-          this.tree.props.sortable &&
-          this.tree.props.sortable.showHandler &&
-          this.tree.props.sortable.byHandler
-            ? '.nom-tree-drag-handler'
-            : null,
-      })
+      const options = isPlainObject(sortable)
+        ? {
+            ...{
+              group: this.key,
+              animation: 150,
+              fallbackOnBody: true,
+              swapThreshold: 0.65,
+              handle:
+                this.tree.props.sortable &&
+                this.tree.props.sortable.showHandler &&
+                this.tree.props.sortable.byHandler
+                  ? '.nom-tree-drag-handler'
+                  : null,
+            },
+            ...sortable,
+          }
+        : {
+            group: this.key,
+            animation: 150,
+            fallbackOnBody: true,
+            swapThreshold: 0.65,
+            handle:
+              this.tree.props.sortable &&
+              this.tree.props.sortable.showHandler &&
+              this.tree.props.sortable.byHandler
+                ? '.nom-tree-drag-handler'
+                : null,
+          }
+      new Sortable(this.element, options)
     }
   }
 

--- a/components/util/index.js
+++ b/components/util/index.js
@@ -225,8 +225,8 @@ export function normalizeKey(key) {
   return key[0] === '-' && key[1] === '-'
     ? key
     : key === 'cssFloat'
-    ? 'float'
-    : key.replace(uppercaseRegex, toLowerCase)
+      ? 'float'
+      : key.replace(uppercaseRegex, toLowerCase)
 }
 
 export function isNumeric(val) {

--- a/components/util/theme/vars.less
+++ b/components/util/theme/vars.less
@@ -9,6 +9,7 @@ body {
   // Font
   --nom-font-family-en: tahoma, arial, 'Helvetica Neue', helvetica, sans-serif;
   --nom-text-color: var(--nom-color-text-0);
+  --nom-text-color-muted: var(--nom-color-text-3);
 
   // Box Element
   --nom-border-radius: 4px;


### PR DESCRIPTION
Grid列设置重构为穿梭框形式

1. 左侧为旧版级联树结构，选中的项目会出现在右侧已选中栏目
2. 右侧已选中栏目中可以进行拖动排序，移除，控制是否冻结
3. 新增frozenLimit配置项控制最多冻结列数（frozenLeftCols不受此配置影响）
4. allowFrozenCols新增子属性showPinner(是否显示表头锚钉按钮)，默认为false