### PR TITLE
feat(Grid): 行展开功能丰富多项api

### DIFF
--- a/components/Component/Component.js
+++ b/components/Component/Component.js
@@ -716,6 +716,7 @@ class Component {
     if (expandedProps) {
       this.update(expandedProps)
     }
+
     isFunction(this._expand) && this._expand()
   }
 

--- a/components/Grid/Grid.js
+++ b/components/Grid/Grid.js
@@ -1,5 +1,4 @@
 import Component from '../Component/index'
-import Icon from '../Icon/index'
 import Loading from '../Loading/index'
 import ExpandedTr from '../Table/ExpandedTr'
 import {
@@ -19,6 +18,7 @@ import {
   isString,
   localeCompareString,
 } from '../util/index'
+import ExpandIndicator from './expandIndicator'
 import GridBody from './GridBody'
 import GridFooter from './GridFooter'
 import GridHeader from './GridHeader'
@@ -1472,28 +1472,35 @@ class Grid extends Component {
               }
 
               return {
-                component: Icon,
+                component: ExpandIndicator,
                 ref: (c) => {
                   row.expandIndicotorIconRef = c
                 },
+                grid: this,
+                row,
                 hidden: true,
                 expandable: {
-                  byClick: true,
-                  expanded: rowExpandable.expanded,
-                  expandedProps: {
-                    type: 'down-circle',
+                  ...{
+                    expandedProps: {
+                      type: 'up-circle',
+                    },
+                    collapsedProps: {
+                      type: 'down-circle',
+                    },
                   },
-                  collapsedProps: {
-                    type: 'up-circle',
-                  },
-                  target: () => {
-                    if (!row.expandedRow) {
-                      row.expandedRow = row.after({
-                        component: ExpandedTr,
-                        data: rowData,
-                      })
-                    }
-                    return row.expandedRow
+                  ...rowExpandable,
+                  ...{
+                    byClick: true,
+                    expanded: rowExpandable.expanded,
+                    target: () => {
+                      if (!row.expandedRow) {
+                        row.expandedRow = row.after({
+                          component: ExpandedTr,
+                          data: rowData,
+                        })
+                      }
+                      return row.expandedRow
+                    },
                   },
                 },
               }

--- a/components/Grid/demos/nest-grid.js
+++ b/components/Grid/demos/nest-grid.js
@@ -1,11 +1,31 @@
-define([], function () {
+define(['css!./nested-grid'], function () {
   return {
-    title: '可展开-嵌套 Grid',
+    title: '可展开-其他配置',
     file: 'nest-grid',
     demo: function () {
       return {
         component: 'Grid',
         rowExpandable: {
+          // 自定义展开图标
+          expandedProps: {
+            type: 'up',
+          },
+          collapsedProps: {
+            type: 'down',
+          },
+          expandSingle: true, // 手风琴模式
+          onExpand: ({ sender, row }) => {
+            // 行展开回调
+            sender.element.querySelectorAll('.expand-highlight').forEach((el) => {
+              el.classList.remove('expand-highlight')
+            })
+            row.element.classList.add('expand-highlight')
+            row.expandedRow.element.classList.add('expand-highlight')
+          },
+          onCollapse: (args) => {
+            // 行折叠回调
+            console.log('onCollapse', args)
+          },
           render: ({ rowData }) => {
             return {
               component: 'Grid',

--- a/components/Grid/demos/nested-grid.css
+++ b/components/Grid/demos/nested-grid.css
@@ -1,0 +1,3 @@
+.expand-highlight {
+  background-color: #fffced !important;
+}

--- a/components/Grid/expandIndicator.js
+++ b/components/Grid/expandIndicator.js
@@ -1,0 +1,44 @@
+import Component from '../Component/index'
+import Icon from '../Icon/index'
+
+class ExpandIcon extends Icon {
+  constructor(props, ...mixins) {
+    const defaults = {}
+
+    super(Component.extendProps(defaults, props), ...mixins)
+  }
+
+  _created() {
+    super._created()
+    this.grid = this.props.grid
+    this.row = this.props.row
+  }
+
+  expand() {
+    if (this.grid.props.rowExpandable.expandSingle === true) {
+      if (this.grid.expandedTrItem) {
+        this.grid.expandedTrItem.collapse()
+      }
+      this.grid.expandedTrItem = this
+    }
+    super.expand()
+
+    if (this.grid.props.rowExpandable.onExpand) {
+      this.grid._callHandler(this.grid.props.rowExpandable.onExpand, { row: this.row })
+    }
+  }
+
+  collapse() {
+    if (this.grid.props.rowExpandable.expandSingle === true) {
+      this.grid.expandedTrItem = null
+    }
+    super.collapse()
+    if (this.grid.props.rowExpandable.onCollapse) {
+      this.grid._callHandler(this.grid.props.rowExpandable.onCollapse, { row: this.row })
+    }
+  }
+}
+
+Component.register(ExpandIcon)
+
+export default ExpandIcon

--- a/components/Grid/index.md
+++ b/components/Grid/index.md
@@ -253,9 +253,14 @@
 
 表格行可展开
 
-| 参数   | 说明             | 类型                  | 默认值 |
-| ------ | ---------------- | --------------------- | ------ |
-| render | 被展开行渲染函数 | `({rowData,row})=>{}` | -      |
+| 参数           | 说明                 | 类型                  | 默认值                 |
+| -------------- | -------------------- | --------------------- | ---------------------- |
+| expandedProps  | 展开状态图标属性定义 | `object`              | `{type:'up-circle'}`   |
+| collapsedProps | 折叠状态图标属性定义 | `object`              | `{type:'down-circle'}` |
+| render         | 被展开行渲染函数     | `({rowData,row})=>{}` | -                      |
+| expandSingle   | 是否只允许展开一项   | `boolean`             | `false`                |
+| onExpand       | 行展开回调           | `({row})=>{}`         | -                      |
+| onCollapse     | 行展开回调           | `({row})=>{}`         | -                      |
 
 ### rowSortable
 

--- a/components/Grid/styles/index.less
+++ b/components/Grid/styles/index.less
@@ -12,6 +12,10 @@
     display: none;
   }
 
+  .nom-expand-icon {
+    cursor: pointer;
+  }
+
   .nom-table-checker-with-toolbar {
     padding-left: 0 !important;
     padding-right: 0 !important;

--- a/components/Menu/MenuItem.js
+++ b/components/Menu/MenuItem.js
@@ -24,7 +24,7 @@ class MenuItem extends Component {
       tools: null,
       key: function () {
         return this.props[this.props.keyField]
-      }
+      },
     }
 
     super(Component.extendProps(defaults, props), ...mixins)
@@ -62,8 +62,7 @@ class MenuItem extends Component {
     if (this.props.tools) {
       if (isFunction(this.props.tools)) {
         tools = this.props.tools(this, menu)
-      }
-      else if (isPlainObject(this.props.tools)) {
+      } else if (isPlainObject(this.props.tools)) {
         tools = this.props.tools
       }
     }
@@ -174,7 +173,7 @@ class MenuItem extends Component {
     }
   }
 
-  handleSelect() { }
+  handleSelect() {}
 
   _collapse() {
     this.indicator && this.indicator.collapse()


### PR DESCRIPTION
 // 自定义展开图标
          expandedProps: {
            type: 'up',
          },
          collapsedProps: {
            type: 'down',
          },
          expandSingle: true, // 手风琴模式
          onExpand: ({ sender, row }) => {
            // 行展开回调
            sender.element.querySelectorAll('.expand-highlight').forEach((el) => {
              el.classList.remove('expand-highlight')
            })
            row.element.classList.add('expand-highlight')
            row.expandedRow.element.classList.add('expand-highlight')
          },
          onCollapse: (args) => {
            // 行折叠回调
            console.log('onCollapse', args)
          },